### PR TITLE
Feat/get oldest pending orders

### DIFF
--- a/src/main/java/Main.java
+++ b/src/main/java/Main.java
@@ -23,8 +23,13 @@ public class Main {
         Order fruitOrder = shopService.addOrder(List.of("1", "2", "5"));
         Order vegetableOrder = shopService.addOrder(List.of("3", "4", "7"));
         Order fishOrder = shopService.addOrder(List.of("6"));
+        Order fruitAndVegOrder = shopService.addOrder(List.of("1","2","3","4"));
+
+        shopService.updateOrder(fruitOrder.id(), OrderStatus.IN_DELIVERY);
+        shopService.updateOrder(vegetableOrder.id(), OrderStatus.IN_DELIVERY);
 
         System.out.println(shopService.getOrdersWithStatus(OrderStatus.PROCESSING));
+        System.out.println(shopService.getOldestOrderPerStatus());
 
     }
 }

--- a/src/main/java/service/ShopService.java
+++ b/src/main/java/service/ShopService.java
@@ -9,7 +9,9 @@ import product.ProductRepo;
 
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 public class ShopService {
@@ -36,6 +38,20 @@ public class ShopService {
 
     public List<Order> getOrdersWithStatus(OrderStatus orderStatus) {
         return orderRepo.getOrders().stream().filter(order -> order.status().equals(orderStatus)).toList();
+    }
+
+    public Map<OrderStatus, Order> getOldestOrderPerStatus() {
+        Map<OrderStatus, Order> oldestOrderByStatusMap = new HashMap<>();
+        for (OrderStatus status : OrderStatus.values()) {
+            try {
+                Order order = getOrdersWithStatus(status).stream().reduce((a,b) -> a.timestamp().isBefore(b.timestamp()) ? a : b).orElseThrow();
+                oldestOrderByStatusMap.put(status, order);
+            } catch (Exception e) {
+                System.out.println("No order present with status: " + status);
+                oldestOrderByStatusMap.put(status, null);
+            }
+        }
+        return oldestOrderByStatusMap;
     }
 
     public Order updateOrder(String orderId, OrderStatus status) {

--- a/src/test/java/ShopServiceTest.java
+++ b/src/test/java/ShopServiceTest.java
@@ -125,4 +125,19 @@ class ShopServiceTest {
         assertEquals(expected, actual);
         assertTrue(actual.isBefore(secondOrder.timestamp()));
     }
+
+    @Test
+    void getOldestOrderByStatusTest_whenNoOrderWithStatus_thenReturnNull() {
+        //GIVEN
+        ProductRepo shopRepo = new ProductRepo();
+        OrderRepo orderRepo = new OrderMapRepo();
+        IdService idService = new IdService();
+        ShopService shopService = new ShopService(shopRepo, orderRepo, idService);
+
+        //WHEN
+        Order actual = shopService.getOldestOrderPerStatus().get(OrderStatus.PROCESSING);
+
+        //THEN
+        assertNull(actual);
+    }
 }

--- a/src/test/java/ShopServiceTest.java
+++ b/src/test/java/ShopServiceTest.java
@@ -8,6 +8,7 @@ import product.ProductRepo;
 import service.IdService;
 import service.ShopService;
 
+import java.time.Instant;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -103,5 +104,25 @@ class ShopServiceTest {
         Order expected = savedOrder.withStatus(OrderStatus.IN_DELIVERY);
         assertEquals(actual, expected);
 
+    }
+
+    @Test
+    void getOldestOrderByStatusTest_whenTwoOrdersWithSameStatus_thenReturnOldest() {
+        //GIVEN
+        ProductRepo shopRepo = new ProductRepo();
+        OrderRepo orderRepo = new OrderMapRepo();
+        IdService idService = new IdService();
+        ShopService shopService = new ShopService(shopRepo, orderRepo, idService);
+        List<String> productsIds = List.of("1");
+        Order firstOrder = shopService.addOrder(productsIds);
+        Order secondOrder = shopService.addOrder(productsIds);
+
+        //WHEN
+        Instant actual = shopService.getOldestOrderPerStatus().get(OrderStatus.PROCESSING).timestamp();
+        Instant expected = firstOrder.timestamp();
+
+        //THEN
+        assertEquals(expected, actual);
+        assertTrue(actual.isBefore(secondOrder.timestamp()));
     }
 }

--- a/src/test/java/ShopServiceTest.java
+++ b/src/test/java/ShopServiceTest.java
@@ -10,6 +10,7 @@ import service.ShopService;
 
 import java.time.Instant;
 import java.util.List;
+import java.util.NoSuchElementException;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -107,7 +108,7 @@ class ShopServiceTest {
     }
 
     @Test
-    void getOldestOrderByStatusTest_whenTwoOrdersWithSameStatus_thenReturnOldest() {
+    void getOldestOrderPerStatusTest_whenTwoOrdersWithSameStatus_thenReturnOldest() {
         //GIVEN
         ProductRepo shopRepo = new ProductRepo();
         OrderRepo orderRepo = new OrderMapRepo();
@@ -127,7 +128,7 @@ class ShopServiceTest {
     }
 
     @Test
-    void getOldestOrderByStatusTest_whenNoOrderWithStatus_thenReturnNull() {
+    void getOldestOrderPerStatusTest_whenNoOrderWithStatus_thenReturnNull() {
         //GIVEN
         ProductRepo shopRepo = new ProductRepo();
         OrderRepo orderRepo = new OrderMapRepo();


### PR DESCRIPTION
- Add getOldestOrderPerStatus() method to ShopService
   - Returns a Map with Order mapped to Order
   - If no order for a specific order status, value will be null
- Add tests for getOldestOrderPerStatus()
   - Checks that out of two orders, the oldest is returned
   - Checks that if no orders for a status, null will be returned
- Implemented in Main