### PR TITLE
Test: add tests for generateId method in IdService

### DIFF
--- a/src/main/java/service/IdService.java
+++ b/src/main/java/service/IdService.java
@@ -1,10 +1,12 @@
 package service;
 
+import lombok.Getter;
+
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
-
+@Getter
 public class IdService {
     private final List<UUID> generatedIds = new ArrayList<>();
 

--- a/src/test/java/service/IdServiceTest.java
+++ b/src/test/java/service/IdServiceTest.java
@@ -1,0 +1,43 @@
+package service;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashSet;
+import java.util.Set;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class IdServiceTest {
+
+    @Test
+    void generateIdTest_whenGeneratingTwice_expectDifferentIds() {
+        //GIVEN
+        IdService idService = new IdService();
+
+        //WHEN
+        UUID id1 = idService.generateId();
+        UUID id2 = idService.generateId();
+
+        //THEN
+        assertNotEquals(id1, id2);
+    }
+
+    @Test
+    void generateIdTest_whenGeneratingId_thenIdIsStored() {
+        IdService idService = new IdService();
+        UUID newId = idService.generateId();
+        assertTrue(idService.getGeneratedIds().contains(newId));
+    }
+
+    @Test
+    void generateIdTest_whenGenerating1000Times_thenNoDuplicateIds() {
+        IdService idService = new IdService();
+        Set<UUID> ids = new HashSet<>();
+        for (int i = 0; i < 1000; i++) {
+            UUID newId = idService.generateId();
+            ids.add(newId);
+        }
+        assertEquals(ids.size(),idService.getGeneratedIds().size());
+    }
+}


### PR DESCRIPTION
Fixes Issue #5 
- Added tests for generateId() method in IdService
- Tests for unique Ids (no duplicates)
- Tests that generated Ids are stored